### PR TITLE
Support ANY label for node labels denoted by *

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/SchedulerUtils.java
@@ -367,6 +367,10 @@ public class SchedulerUtils {
     }
 
     if (labelExpression != null) {
+      if(labelExpression.contains(RMNodeLabelsManager.ANY)) {
+          return true;
+      }
+
       for (String str : labelExpression.split("&&")) {
         if (!str.trim().isEmpty()
             && (nodeLabels == null || !nodeLabels.contains(str.trim()))) {
@@ -403,7 +407,8 @@ public class SchedulerUtils {
         // check node label manager contains this label
         if (null != rmContext) {
           RMNodeLabelsManager nlm = rmContext.getNodeLabelManager();
-          if (nlm != null && !nlm.containsNodeLabel(str)) {
+          if (nlm != null && !nlm.containsNodeLabel(str)
+              && !str.contains(RMNodeLabelsManager.ANY)) {
             return false;
           }
         }


### PR DESCRIPTION
Currently, if you put a \* as a node label expression for any queues, refreshQueue fails. This patch takes care of it and causes containers to be assigned to all the nodes.
