### PR TITLE
Adding code to read from distcp-site.xml and changed options behavior…

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -70,6 +70,7 @@ public class DistCp extends Configured implements Tool {
   private static final String PREFIX = "_distcp";
   private static final String WIP_PREFIX = "._WIP_";
   private static final String DISTCP_DEFAULT_XML = "distcp-default.xml";
+  private static final String DISTCP_SITE_XML = "distcp-site.xml";
   static final Random rand = new Random();
 
   private boolean submitted;
@@ -85,6 +86,7 @@ public class DistCp extends Configured implements Tool {
   public DistCp(Configuration configuration, DistCpOptions inputOptions) throws Exception {
     Configuration config = new Configuration(configuration);
     config.addResource(DISTCP_DEFAULT_XML);
+    config.addResource(DISTCP_SITE_XML);
     setConf(config);
     this.inputOptions = inputOptions;
     this.metaFolder   = createMetaFolderPath();
@@ -439,11 +441,12 @@ public class DistCp extends Configured implements Tool {
   /**
    * Loads properties from distcp-default.xml into configuration
    * object
-   * @return Configuration which includes properties from distcp-default.xml
+   * @return Configuration which includes properties from distcp-default.xml and distcp-site.xml
    */
   private static Configuration getDefaultConf() {
     Configuration config = new Configuration();
     config.addResource(DISTCP_DEFAULT_XML);
+    config.addResource(DISTCP_SITE_XML);
     return config;
   }
 

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
@@ -47,7 +47,7 @@ public class DistCpOptions {
   public static final int maxNumListstatusThreads = 40;
   private int numListstatusThreads = 0;  // Indicates that flag is not set.
   private int maxMaps = DistCpConstants.DEFAULT_MAPS;
-  private int mapBandwidth = DistCpConstants.DEFAULT_BANDWIDTH_MB;
+  private int mapBandwidth = 0;  // Indicates that we should use the default.
 
   private String sslConfigurationFile;
 
@@ -619,8 +619,10 @@ public class DistCpOptions {
         String.valueOf(useDiff));
     DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.SKIP_CRC,
         String.valueOf(skipCRC));
-    DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.BANDWIDTH,
-        String.valueOf(mapBandwidth));
+    if (mapBandwidth > 0) {
+      DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.BANDWIDTH,
+          String.valueOf(mapBandwidth));
+    }
     DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.PRESERVE_STATUS,
         DistCpUtils.packAttributes(preserveStatus));
   }


### PR DESCRIPTION
… so it doesn't overwrite distcp.map.bandwidth.mb from config unless -bandwidth option is set.

Updated unittests.
