### PR TITLE
Reduce DFSOutputStream closeResponder() noise

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -715,7 +715,7 @@ public class DFSOutputStream extends FSOutputSummer
           response.close();
           response.join();
         } catch (InterruptedException  e) {
-          DFSClient.LOG.warn("Caught exception ", e);
+          DFSClient.LOG.debug("Caught exception ", e);
         } finally {
           response = null;
         }


### PR DESCRIPTION
During submission of a Yarn MapReduce job, the DFS client will throw multiple warnings that do nothing but create noise for the user. DFSOutputStream closeResponder() is expected to force threads to close since HDFS-9812. I propose we adjust the log level here, so our users don't get bombarded with meaningless noise that offer no apparent value.

https://altiscale.atlassian.net/browse/HD-2141