### PR TITLE
BLUE-314 Add support for s3 Requester Pays

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -33,6 +33,10 @@ public class Constants {
   public static final String SECURE_CONNECTIONS = "fs.s3a.connection.ssl.enabled";
   public static final boolean DEFAULT_SECURE_CONNECTIONS = true;
 
+  //allow access to requester pay buckets
+  public static final String ALLOW_REQUESTER_PAYS = "fs.s3a.requester-pays.enabled";
+  public static final boolean DEFAULT_ALLOW_REQUESTER_PAYS = false;
+
   //use a custom endpoint?
   public static final String ENDPOINT = "fs.s3a.endpoint";
   //connect to s3 through a proxy server?


### PR DESCRIPTION
To support for S3 Requester Pays API. Unfortunately the patch in https://issues.apache.org/jira/browse/HADOOP-14661 is not compatible with our 2.7.7 code base. Both hadoop AWS and AWS SDK are refactored.

Anyways, figured out required changes and submitted these changes. Unfortunately there are no unit tests for this set of AWS hadoop integration. We have to manually test this.

Thanks,
Narendra